### PR TITLE
feat: distribute precompiled framework

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set Xcode 13.4
+      - name: Set Xcode 14.3.1
         run: |
-          sudo xcode-select -switch /Applications/Xcode_13.4.app
+          sudo xcode-select -switch /Applications/Xcode_14.3.1.app
 
       - name: iOS Build 
         run: |
@@ -86,6 +86,12 @@ jobs:
 
       - name: Validate Podfile
         run: pod lib lint --allow-warnings
+
+      - name: Build xcframework
+        run: scripts/build_framework.sh
+      
+      - name: Zip xcframework
+        run: zip -r .build/artifacts/AnalyticsConnector.xcframework.zip .build/artifacts/AnalyticsConnector.xcframework
 
       - name: Semantic Release --dry-run
         if: ${{ github.event.inputs.dryRun == 'true'}}

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   pr-title-check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: PR title is valid
         if: >

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
       - name: Checkout 
         uses: actions/checkout@v2
 
-      - name: Set Xcode 13.4
+      - name: Set Xcode 14.3.1
         run: |
-          sudo xcode-select -switch /Applications/Xcode_13.4.app
+          sudo xcode-select -switch /Applications/Xcode_14.3.1.app
 
       - name: iOS Build 
         run: |

--- a/release.config.js
+++ b/release.config.js
@@ -13,7 +13,12 @@ module.exports = {
     ["@semantic-release/changelog", {
       "changelogFile": "CHANGELOG.md"
     }],
-    "@semantic-release/github",
+    [
+      "@semantic-release/github", {
+        "assets": [
+          { "path": ".build/artifacts/AnalyticsConnector.xcframework.zip" },
+        ]
+    }],
     [
       "@google/semantic-release-replace-plugin",
       {

--- a/scripts/build_framework.sh
+++ b/scripts/build_framework.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e
+
+SCHEME="AnalyticsConnector"
+FRAMEWORK="AnalyticsConnector"
+BUILD_DIR="./.build/artifacts"
+OUTPUT_PATH="$BUILD_DIR/$FRAMEWORK.xcframework"
+PLATFORMS=("macOS" "iOS" "iOS Simulator" "tvOS" "tvOS Simulator" "watchOS" "watchOS Simulator")
+
+build_framework_with_configuration_and_name() {
+    CONFIGURATION=${1}
+    # Create a framework for each supported sdk
+    declare -a ARCHIVES
+    for PLATFORM in "${PLATFORMS[@]}"
+    do
+        ARCHIVE="$BUILD_DIR/$CONFIGURATION/$FRAMEWORK-$PLATFORM.xcarchive"
+        xcodebuild archive \
+            -scheme "$SCHEME" \
+            -configuration "$CONFIGURATION" \
+            -archivePath "$ARCHIVE" \
+            -destination "generic/platform=$PLATFORM" \
+            SKIP_INSTALL=NO \
+            BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+        ARCHIVES+=("$ARCHIVE")
+    done
+
+    # then bundle them into an xcframework
+    CREATE_XCFRAMEWORK="xcodebuild -create-xcframework -output '$OUTPUT_PATH'"
+    for ARCHIVE in "${ARCHIVES[@]}"
+    do
+        CREATE_XCFRAMEWORK="$CREATE_XCFRAMEWORK -archive '$ARCHIVE' -framework '$FRAMEWORK.framework'"
+    done
+    eval "$CREATE_XCFRAMEWORK"
+
+    # Fixup - Resolve module/class name conflicts
+    for SWIFT_INTERFACE in $(find "$OUTPUT_PATH" -name "*.private.swiftinterface")
+    do
+        sed -i "" "s/AnalyticsConnector\.//" "$SWIFT_INTERFACE"
+    done
+}
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+build_framework_with_configuration_and_name "Release" "AnalyticsConnector"


### PR DESCRIPTION
### Summary

We want to start distributing Amplitude-Swift as a precompiled package, which means compiling it with BUILD_LIBRARY_FOR_DISTRIBUTION (this enables compatibility with future swift compilers, which is why we still target the oldest supported version on macos-latest) and packaging it as an XCFramework. Most build systems will also want dependencies to conform to this as well.

This PR adds a script to create the xcframework, then add it as an artifact to our [releases](https://github.com/amplitude/analytics-connector-ios/releases). Initially, this will only be picked up by Carthage builds. Once I can test with an actual release, I'll add an other option for SPM to just use the precompiled version.

Successful release dry run: https://github.com/amplitude/analytics-connector-ios/actions/runs/11512316382

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/amplitude-ios-iterop/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
