### PR TITLE
fix: don't include build path in zipped artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,8 @@ jobs:
         run: scripts/build_framework.sh
       
       - name: Zip xcframework
-        run: zip -r .build/artifacts/AnalyticsConnector.xcframework.zip .build/artifacts/AnalyticsConnector.xcframework
+        working-directory: .build/artifacts
+        run: zip -r AnalyticsConnector.xcframework.zip AnalyticsConnector.xcframework
 
       - name: Semantic Release --dry-run
         if: ${{ github.event.inputs.dryRun == 'true'}}

--- a/AnalyticsConnector.xcodeproj/project.pbxproj
+++ b/AnalyticsConnector.xcodeproj/project.pbxproj
@@ -270,7 +270,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amplitude.AnalyticsConnector;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchos watchsimulator appletvos appletvsimulator macosx";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_INSTALL_OBJC_HEADER = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -303,7 +304,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amplitude.AnalyticsConnector;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos watchos watchsimulator appletvos appletvsimulator macosx";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_INSTALL_OBJC_HEADER = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";

--- a/scripts/build_framework.sh
+++ b/scripts/build_framework.sh
@@ -6,7 +6,7 @@ SCHEME="AnalyticsConnector"
 FRAMEWORK="AnalyticsConnector"
 BUILD_DIR="./.build/artifacts"
 OUTPUT_PATH="$BUILD_DIR/$FRAMEWORK.xcframework"
-PLATFORMS=("macOS" "iOS" "iOS Simulator" "tvOS" "tvOS Simulator" "watchOS" "watchOS Simulator")
+PLATFORMS=("iOS" "iOS Simulator" "macOS" "macOS Cataylst" "watchOS" "watchOS Simulator" "tvOS" "tvOS Simulator")
 
 build_framework_with_configuration_and_name() {
     CONFIGURATION=${1}
@@ -15,13 +15,25 @@ build_framework_with_configuration_and_name() {
     for PLATFORM in "${PLATFORMS[@]}"
     do
         ARCHIVE="$BUILD_DIR/$CONFIGURATION/$FRAMEWORK-$PLATFORM.xcarchive"
-        xcodebuild archive \
-            -scheme "$SCHEME" \
-            -configuration "$CONFIGURATION" \
-            -archivePath "$ARCHIVE" \
-            -destination "generic/platform=$PLATFORM" \
-            SKIP_INSTALL=NO \
-            BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+        if [[ "$PLATFORM" == "macOS Cataylst" ]]
+        then
+            xcodebuild archive \
+                -scheme "$SCHEME" \
+                -configuration "$CONFIGURATION" \
+                -archivePath "$ARCHIVE" \
+                -destination "generic/platform=macOS,variant=Mac Catalyst" \
+                SKIP_INSTALL=NO \
+                BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+                SUPPORTS_MACCATALYST=YES
+        else
+            xcodebuild archive \
+                -scheme "$SCHEME" \
+                -configuration "$CONFIGURATION" \
+                -archivePath "$ARCHIVE" \
+                -destination "generic/platform=$PLATFORM" \
+                SKIP_INSTALL=NO \
+                BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+        fi
         ARCHIVES+=("$ARCHIVE")
     done
 


### PR DESCRIPTION
### Summary

Currently the zip file includes the `.build/artifacts` path, this change correctly puts the xcframework at the root of the zip file. Also, this adds support for macos catalyst, which Analytics-Swift supports.

successful release dry run: https://github.com/amplitude/analytics-connector-ios/actions/runs/11584167224

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/amplitude-ios-iterop/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
