### PR TITLE
feat: add binary spm distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,11 @@ jobs:
         working-directory: .build/artifacts
         run: zip -r AnalyticsConnector.xcframework.zip AnalyticsConnector.xcframework
 
+      - name: Update Checksum
+        run: |
+          CHECKSUM=$(xcrun swift package compute-checksum .build/artifacts/AnalyticsConnector.xcframework.zip) && \
+          sed -i '' -E "s/(checksum: \")[^\"]*(\")/\1$CHECKSUM\2/" Package.swift
+
       - name: Semantic Release --dry-run
         if: ${{ github.event.inputs.dryRun == 'true'}}
         env:

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,9 @@ let package = Package(
             name: "AnalyticsConnector",
             path: "Sources/AnalyticsConnector",
             exclude: ["Info.plist"]),
+        .binaryTarget(name: "AnalyticsConnectorFramework",
+            url: "https://github.com/amplitude/analytics-connector-ios/releases/download/v1.1.1/AnalyticsConnector.xcframework.zip",
+            checksum: "4d5ecd7301d34ef4cfb91a799e8d32940fd7c9eac4b5ab62b820ad447d18b594"),
         .testTarget(
             name: "AnalyticsConnectorTests",
             dependencies: ["AnalyticsConnector"],

--- a/release.config.js
+++ b/release.config.js
@@ -37,6 +37,20 @@ module.exports = {
             ],
             "countMatches": true
           },
+          {
+            "files": ["Package.swift"],
+            "from": "https://github.com/amplitude/analytics-connector-ios/releases/download/v.*/AnalyticsConnector.xcframework.zip",
+            "to": "https://github.com/amplitude/analytics-connector-ios/releases/download/v${nextRelease.version}/AnalyticsConnector.xcframework.zip",
+            "results": [
+              {
+                "file": "Package.swift",
+                "hasChanged": true,
+                "numMatches": 1,
+                "numReplacements": 1
+              }
+            ],
+            "countMatches": true
+          },
         ]
       }
     ],


### PR DESCRIPTION
### Summary

Adds an SPM binary target, pointing to the framework on. GitHub releases.

Successful release dry run: https://github.com/amplitude/analytics-connector-ios/actions/runs/11598538315/job/32294612572

though, it looks like I will have to run a release to fully test everything.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/amplitude-ios-iterop/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
