### PR TITLE
feat: add visionOS Support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Setup Cocoapods
         uses: maxim-lobanov/setup-cocoapods@v1.4.0
         with:
-          cocoapods-version: latest
+          version: latest
 
       - name: Validate Podfile
         run: pod lib lint --allow-warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,8 +104,9 @@ jobs:
       - name: Show Installed Simulators
         run: xcrun simctl list
 
-      - name: Install missing Simulators
-        run: xcodebuild -downloadAllPlatforms
+      # remove this step after update the os runner to 15
+      - name: Install visionOS simulator
+        run: xcodebuild -downloadPlatform visionOS
 
       - name: Show Installed Simulators
         run: xcrun simctl list
@@ -116,10 +117,10 @@ jobs:
       - name: Validate Podfile
         run: pod --version
 
-      - name: Setup Cocoapods
-        uses: maxim-lobanov/setup-cocoapods@v1.4.0
-        with:
-          version: latest
+      # - name: Setup Cocoapods
+      #   uses: maxim-lobanov/setup-cocoapods@v1.4.0
+      #   with:
+      #     version: latest
 
       - name: Validate Podfile after reinstall
         run: pod --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,96 +34,77 @@ jobs:
         run: |
           sudo xcode-select -switch /Applications/Xcode_15.4.app
 
-      # - name: iOS Build 
-      #   run: |
-      #     xcodebuild \
-      #       -project AnalyticsConnector.xcodeproj \
-      #       -scheme AnalyticsConnector \
-      #       -sdk iphonesimulator \
-      #       -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.5'
+      - name: iOS Build 
+        run: |
+          xcodebuild \
+            -project AnalyticsConnector.xcodeproj \
+            -scheme AnalyticsConnector \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.5'
 
-      # - name: macOS Build 
-      #   run: |
-      #     xcodebuild \
-      #       -project AnalyticsConnector.xcodeproj \
-      #       -scheme AnalyticsConnector \
-      #       -sdk macosx \
-      #       -destination 'platform=macosx' \
+      - name: macOS Build 
+        run: |
+          xcodebuild \
+            -project AnalyticsConnector.xcodeproj \
+            -scheme AnalyticsConnector \
+            -sdk macosx \
+            -destination 'platform=macosx' \
 
-      # - name: tvOS Build 
-      #   run: |
-      #     xcodebuild \
-      #       -project AnalyticsConnector.xcodeproj \
-      #       -scheme AnalyticsConnector \
-      #       -sdk appletvsimulator \
-      #       -destination 'platform=tvOS Simulator,name=Apple TV' \
+      - name: tvOS Build 
+        run: |
+          xcodebuild \
+            -project AnalyticsConnector.xcodeproj \
+            -scheme AnalyticsConnector \
+            -sdk appletvsimulator \
+            -destination 'platform=tvOS Simulator,name=Apple TV' \
 
-      # - name: xrOS Build 
-      #   run: |
-      #     xcodebuild \
-      #       -project AnalyticsConnector.xcodeproj \
-      #       -scheme AnalyticsConnector \
-      #       -sdk xrsimulator \
-      #       -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+      - name: visionOS Build
+        run: |
+          xcodebuild \
+            -project AnalyticsConnector.xcodeproj \
+            -scheme AnalyticsConnector \
+            -sdk xrsimulator \
+            -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
 
-      # - name: iOS Tests
-      #   run: |
-      #     xcodebuild test \
-      #       -project AnalyticsConnector.xcodeproj \
-      #       -scheme AnalyticsConnector \
-      #       -sdk iphonesimulator \
-      #       -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.5'
+      - name: iOS Tests
+        run: |
+          xcodebuild test \
+            -project AnalyticsConnector.xcodeproj \
+            -scheme AnalyticsConnector \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.5'
 
-      # - name: macOS Tests
-      #   run: |
-      #     xcodebuild \
-      #       -project AnalyticsConnector.xcodeproj \
-      #       -scheme AnalyticsConnector \
-      #       -sdk macosx \
-      #       -destination 'platform=macosx' \
-      #       test
+      - name: macOS Tests
+        run: |
+          xcodebuild \
+            -project AnalyticsConnector.xcodeproj \
+            -scheme AnalyticsConnector \
+            -sdk macosx \
+            -destination 'platform=macosx' \
+            test
 
-      # - name: tvOS Tests
-      #   run: |
-      #     xcodebuild \
-      #       -project AnalyticsConnector.xcodeproj \
-      #       -scheme AnalyticsConnector \
-      #       -sdk appletvsimulator \
-      #       -destination 'platform=tvOS Simulator,name=Apple TV' \
-      #       test
+      - name: tvOS Tests
+        run: |
+          xcodebuild \
+            -project AnalyticsConnector.xcodeproj \
+            -scheme AnalyticsConnector \
+            -sdk appletvsimulator \
+            -destination 'platform=tvOS Simulator,name=Apple TV' \
+            test
 
-      # - name: visionOS Tests
-      #   run: |
-      #     xcodebuild \
-      #       -project AnalyticsConnector.xcodeproj \
-      #       -scheme AnalyticsConnector \
-      #       -sdk xrsimulator \
-      #       -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
-      #       test
+      - name: visionOS Tests
+        run: |
+          xcodebuild \
+            -project AnalyticsConnector.xcodeproj \
+            -scheme AnalyticsConnector \
+            -sdk xrsimulator \
+            -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+            test
 
-      - name: Show Installed Simulators
-        run: xcrun simctl list
-
-      # remove this step after update the os runner to 15
+      # Install missing sdk for pod lint
+      # Remove this step after the runner upgraded to macos-15
       - name: Install visionOS simulator
-        run: xcodebuild -downloadPlatform visionOS
-
-      - name: Show Installed Simulators
-        run: xcrun simctl list
-      
-      - name: Show Installed Simulators
-        run: xcodebuild -showsdks
-      
-      - name: Validate Podfile
-        run: pod --version
-
-      # - name: Setup Cocoapods
-      #   uses: maxim-lobanov/setup-cocoapods@v1.4.0
-      #   with:
-      #     version: latest
-
-      - name: Validate Podfile after reinstall
-        run: pod --version
+        run: xcodebuild -downloadPlatform visionOS -quiet
 
       - name: Validate Podfile
         run: pod lib lint --allow-warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,77 +34,78 @@ jobs:
         run: |
           sudo xcode-select -switch /Applications/Xcode_15.4.app
 
-      - name: iOS Build 
-        run: |
-          xcodebuild \
-            -project AnalyticsConnector.xcodeproj \
-            -scheme AnalyticsConnector \
-            -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.5'
+      # - name: iOS Build 
+      #   run: |
+      #     xcodebuild \
+      #       -project AnalyticsConnector.xcodeproj \
+      #       -scheme AnalyticsConnector \
+      #       -sdk iphonesimulator \
+      #       -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.5'
 
-      - name: macOS Build 
-        run: |
-          xcodebuild \
-            -project AnalyticsConnector.xcodeproj \
-            -scheme AnalyticsConnector \
-            -sdk macosx \
-            -destination 'platform=macosx' \
+      # - name: macOS Build 
+      #   run: |
+      #     xcodebuild \
+      #       -project AnalyticsConnector.xcodeproj \
+      #       -scheme AnalyticsConnector \
+      #       -sdk macosx \
+      #       -destination 'platform=macosx' \
 
-      - name: tvOS Build 
-        run: |
-          xcodebuild \
-            -project AnalyticsConnector.xcodeproj \
-            -scheme AnalyticsConnector \
-            -sdk appletvsimulator \
-            -destination 'platform=tvOS Simulator,name=Apple TV' \
+      # - name: tvOS Build 
+      #   run: |
+      #     xcodebuild \
+      #       -project AnalyticsConnector.xcodeproj \
+      #       -scheme AnalyticsConnector \
+      #       -sdk appletvsimulator \
+      #       -destination 'platform=tvOS Simulator,name=Apple TV' \
 
-      - name: xrOS Build 
-        run: |
-          xcodebuild \
-            -project AnalyticsConnector.xcodeproj \
-            -scheme AnalyticsConnector \
-            -sdk xrsimulator \
-            -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+      # - name: xrOS Build 
+      #   run: |
+      #     xcodebuild \
+      #       -project AnalyticsConnector.xcodeproj \
+      #       -scheme AnalyticsConnector \
+      #       -sdk xrsimulator \
+      #       -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
 
-      - name: iOS Tests
-        run: |
-          xcodebuild test \
-            -project AnalyticsConnector.xcodeproj \
-            -scheme AnalyticsConnector \
-            -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.5'
+      # - name: iOS Tests
+      #   run: |
+      #     xcodebuild test \
+      #       -project AnalyticsConnector.xcodeproj \
+      #       -scheme AnalyticsConnector \
+      #       -sdk iphonesimulator \
+      #       -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.5'
 
-      - name: macOS Tests
-        run: |
-          xcodebuild \
-            -project AnalyticsConnector.xcodeproj \
-            -scheme AnalyticsConnector \
-            -sdk macosx \
-            -destination 'platform=macosx' \
-            test
+      # - name: macOS Tests
+      #   run: |
+      #     xcodebuild \
+      #       -project AnalyticsConnector.xcodeproj \
+      #       -scheme AnalyticsConnector \
+      #       -sdk macosx \
+      #       -destination 'platform=macosx' \
+      #       test
 
-      - name: tvOS Tests
-        run: |
-          xcodebuild \
-            -project AnalyticsConnector.xcodeproj \
-            -scheme AnalyticsConnector \
-            -sdk appletvsimulator \
-            -destination 'platform=tvOS Simulator,name=Apple TV' \
-            test
+      # - name: tvOS Tests
+      #   run: |
+      #     xcodebuild \
+      #       -project AnalyticsConnector.xcodeproj \
+      #       -scheme AnalyticsConnector \
+      #       -sdk appletvsimulator \
+      #       -destination 'platform=tvOS Simulator,name=Apple TV' \
+      #       test
 
-      - name: visionOS Tests
-        run: |
-          xcodebuild \
-            -project AnalyticsConnector.xcodeproj \
-            -scheme AnalyticsConnector \
-            -sdk xrsimulator \
-            -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
-            test
+      # - name: visionOS Tests
+      #   run: |
+      #     xcodebuild \
+      #       -project AnalyticsConnector.xcodeproj \
+      #       -scheme AnalyticsConnector \
+      #       -sdk xrsimulator \
+      #       -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+      #       test
+
+      - name: Show Installed Simulators
+        run: xcrun simctl list
       
-      - name: Setup Cocoapods
-        uses: maxim-lobanov/setup-cocoapods@v1.4.0
-        with:
-          version: latest
+      - name: Validate Podfile
+        run: pod --version
 
       - name: Validate Podfile
         run: pod lib lint --allow-warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,10 +105,13 @@ jobs:
         run: xcrun simctl list
 
       - name: Install missing Simulators
-        run: sudo xcodebuild -installAdditionalComponents
+        run: xcodebuild -downloadAllPlatforms
 
       - name: Show Installed Simulators
         run: xcrun simctl list
+      
+      - name: Show Installed Simulators
+        run: xcodebuild -showsdks
       
       - name: Validate Podfile
         run: pod --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,14 @@ jobs:
             -sdk appletvsimulator \
             -destination 'platform=tvOS Simulator,name=Apple TV' \
 
+      - name: xrOS Build 
+        run: |
+          xcodebuild \
+            -project AnalyticsConnector.xcodeproj \
+            -scheme AnalyticsConnector \
+            -sdk xrsimulator \
+            -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+
       - name: iOS Tests
         run: |
           xcodebuild test \
@@ -82,6 +90,15 @@ jobs:
             -scheme AnalyticsConnector \
             -sdk appletvsimulator \
             -destination 'platform=tvOS Simulator,name=Apple TV' \
+            test
+
+      - name: visionOS Tests
+        run: |
+          xcodebuild \
+            -project AnalyticsConnector.xcodeproj \
+            -scheme AnalyticsConnector \
+            -sdk xrsimulator \
+            -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
             test
 
       - name: Validate Podfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,12 @@ jobs:
 
       - name: Show Installed Simulators
         run: xcrun simctl list
+
+      - name: Install missing Simulators
+        run: sudo xcodebuild -installAdditionalComponents
+
+      - name: Show Installed Simulators
+        run: xcrun simctl list
       
       - name: Validate Podfile
         run: pod --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set Xcode 14.3.1
+      - name: Set Xcode 15.4
         run: |
-          sudo xcode-select -switch /Applications/Xcode_14.3.1.app
+          sudo xcode-select -switch /Applications/Xcode_15.4.app
 
       - name: iOS Build 
         run: |
@@ -100,6 +100,11 @@ jobs:
             -sdk xrsimulator \
             -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
             test
+      
+      - name: Setup Cocoapods
+        uses: maxim-lobanov/setup-cocoapods@v1.4.0
+        with:
+          cocoapods-version: latest
 
       - name: Validate Podfile
         run: pod lib lint --allow-warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,14 @@ jobs:
       - name: Validate Podfile
         run: pod --version
 
+      - name: Setup Cocoapods
+        uses: maxim-lobanov/setup-cocoapods@v1.4.0
+        with:
+          version: latest
+
+      - name: Validate Podfile after reinstall
+        run: pod --version
+
       - name: Validate Podfile
         run: pod lib lint --allow-warnings
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,9 @@ jobs:
       - name: Update Checksum
         run: |
           CHECKSUM=$(xcrun swift package compute-checksum .build/artifacts/AnalyticsConnector.xcframework.zip) && \
-          sed -i '' -E "s/(checksum: \")[^\"]*(\")/\1$CHECKSUM\2/" Package.swift
+          sed -i '' -E "s/(checksum: \")[^\"]*(\")/\1$CHECKSUM\2/" Package.swift && \
+          sed -i '' -E "s/(checksum: \")[^\"]*(\")/\1$CHECKSUM\2/" Package@swift-5.9.swift
+
 
       - name: Semantic Release --dry-run
         if: ${{ github.event.inputs.dryRun == 'true'}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
             -sdk appletvsimulator \
             -destination 'platform=tvOS Simulator,name=Apple TV' \
 
-      - name: xrOS Build 
+      - name: visionOS Build 
         run: |
           xcodebuild \
             -project AnalyticsConnector.xcodeproj \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
       - name: Checkout 
         uses: actions/checkout@v2
 
-      - name: Set Xcode 14.3.1
+      - name: Set Xcode 15.4
         run: |
-          sudo xcode-select -switch /Applications/Xcode_14.3.1.app
+          sudo xcode-select -switch /Applications/Xcode_15.4.app
 
       - name: iOS Build 
         run: |
@@ -40,6 +40,14 @@ jobs:
             -scheme AnalyticsConnector \
             -sdk appletvsimulator \
             -destination 'platform=tvOS Simulator,name=Apple TV' \
+
+      - name: xrOS Build 
+        run: |
+          xcodebuild \
+            -project AnalyticsConnector.xcodeproj \
+            -scheme AnalyticsConnector \
+            -sdk xrsimulator \
+            -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
 
       - name: iOS Tests
         run: |
@@ -67,3 +75,11 @@ jobs:
             -destination 'platform=tvOS Simulator,name=Apple TV' \
             test
 
+      - name: visionOS Tests
+        run: |
+          xcodebuild \
+            -project AnalyticsConnector.xcodeproj \
+            -scheme AnalyticsConnector \
+            -sdk xrsimulator \
+            -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+            test

--- a/AnalyticsConnector.podspec
+++ b/AnalyticsConnector.podspec
@@ -24,6 +24,9 @@ Pod::Spec.new do |spec|
   spec.watchos.deployment_target = '3.0'
   spec.watchos.source_files      = 'sources/AnalyticsConnector/**/*.{h,swift}'
 
+  spec.visionos.deployment_target = '1.0'
+  spec.visionos.source_files      = 'sources/AnalyticsConnector/**/*.{h,swift}'
+
   spec.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
 end

--- a/AnalyticsConnector.xcodeproj/project.pbxproj
+++ b/AnalyticsConnector.xcodeproj/project.pbxproj
@@ -270,12 +270,12 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amplitude.AnalyticsConnector;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_INSTALL_OBJC_HEADER = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6,7";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
@@ -304,11 +304,11 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amplitude.AnalyticsConnector;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_INSTALL_OBJC_HEADER = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6,7";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};

--- a/AnalyticsConnector.xcodeproj/project.pbxproj
+++ b/AnalyticsConnector.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -13,7 +13,7 @@
 		2001756927728E16001C341D /* IdentityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2001756827728E16001C341D /* IdentityStore.swift */; };
 		2001756F2773B679001C341D /* EventBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2001756E2773B679001C341D /* EventBridgeTests.swift */; };
 		200175752773D888001C341D /* IdentityStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200175742773D888001C341D /* IdentityStoreTests.swift */; };
-		20C47A8E297A674F0084AC03 /* AnalyticsConnector.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 200174A52771569E001C341D /* AnalyticsConnector.framework */; };
+		20C47A8E297A674F0084AC03 /* AnalyticsConnector.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 200174A52771569E001C341D /* AnalyticsConnector.framework */; platformFilters = (ios, macos, tvos, xros, ); };
 		20C9FAB1278CB1C000A4D530 /* ObjectiveCTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 20C9FAB0278CB1C000A4D530 /* ObjectiveCTests.m */; };
 		20C9FAD4278CBFAC00A4D530 /* AnalyticsConnector.h in Headers */ = {isa = PBXBuildFile; fileRef = 20866C9B27714900003D1705 /* AnalyticsConnector.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
@@ -331,11 +331,12 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amplitude.AnalyticsConnectorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvos appletvsimulator";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,3,6";
+				TARGETED_DEVICE_FAMILY = "1,2,3,6,7";
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Debug;
@@ -357,10 +358,11 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amplitude.AnalyticsConnectorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvos appletvsimulator";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,3,6";
+				TARGETED_DEVICE_FAMILY = "1,2,3,6,7";
 				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Release;

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -9,7 +9,8 @@ let package = Package(
         .iOS(.v10),
         .macOS(.v10_13),
         .tvOS(.v9),
-        .watchOS(.v3)
+        .watchOS(.v3),
+        .visionOS(.v1),
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -9,7 +9,7 @@ let package = Package(
         .iOS(.v10),
         .macOS(.v10_13),
         .tvOS(.v9),
-        .watchOS(.v3),
+        .watchOS(.v3)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -10,6 +10,7 @@ let package = Package(
         .macOS(.v10_13),
         .tvOS(.v9),
         .watchOS(.v3),
+        .visionOS(.v1),
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/release.config.js
+++ b/release.config.js
@@ -51,11 +51,25 @@ module.exports = {
             ],
             "countMatches": true
           },
+          {
+            "files": ["Package@swift-5.9.swift"],
+            "from": "https://github.com/amplitude/analytics-connector-ios/releases/download/v.*/AnalyticsConnector.xcframework.zip",
+            "to": "https://github.com/amplitude/analytics-connector-ios/releases/download/v${nextRelease.version}/AnalyticsConnector.xcframework.zip",
+            "results": [
+              {
+                "file": "Package@swift-5.9.swift",
+                "hasChanged": true,
+                "numMatches": 1,
+                "numReplacements": 1
+              }
+            ],
+            "countMatches": true
+          },
         ]
       }
     ],
     ["@semantic-release/git", {
-      "assets": ["AnalyticsConnector.podspec", "CHANGELOG.md", "Package.swift"],
+      "assets": ["AnalyticsConnector.podspec", "CHANGELOG.md", "Package.swift", "Package@swift-5.9.swift"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
     ["@semantic-release/exec", {

--- a/scripts/build_framework.sh
+++ b/scripts/build_framework.sh
@@ -6,7 +6,7 @@ SCHEME="AnalyticsConnector"
 FRAMEWORK="AnalyticsConnector"
 BUILD_DIR="./.build/artifacts"
 OUTPUT_PATH="$BUILD_DIR/$FRAMEWORK.xcframework"
-PLATFORMS=("iOS" "iOS Simulator" "macOS" "macOS Cataylst" "watchOS" "watchOS Simulator" "tvOS" "tvOS Simulator")
+PLATFORMS=("iOS" "iOS Simulator" "macOS" "macOS Cataylst" "watchOS" "watchOS Simulator" "tvOS" "tvOS Simulator" "visionOS" "visionOS Simulator")
 
 build_framework_with_configuration_and_name() {
     CONFIGURATION=${1}


### PR DESCRIPTION
### Summary

Fix for https://github.com/amplitude/Amplitude-Swift/issues/130: attach vender system information in visionOS.
Add visionOS as supported target

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/amplitude-ios-iterop/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
