### PR TITLE
fix: support target deprecated warning on spm

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
     name: "analytics-connector-ios",
     platforms: [
-        .iOS(.v10),
+        .iOS(.v12),
         .macOS(.v10_13),
-        .tvOS(.v9),
-        .watchOS(.v3),
+        .tvOS(.v12),
+        .watchOS(.v4),
         .visionOS(.v1),
     ],
     products: [


### PR DESCRIPTION
### Summary

Fix for https://github.com/amplitude/analytics-connector-ios/issues/11, a target deprecated warning on SPM

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/amplitude-ios-iterop/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
