### PR TITLE
chore: fix release Node engine failure and align CI environment with the suite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
           xcrun simctl list > /dev/null
           sudo xcodebuild -downloadPlatform iOS
           sudo xcodebuild -downloadPlatform tvOS
+          # watchOS runtime is not built directly but pod lib lint validates
+          # every platform the podspec declares, including watchOS
+          sudo xcodebuild -downloadPlatform watchOS
           sudo xcodebuild -downloadPlatform visionOS
 
       - name: iOS Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
             -project AnalyticsConnector.xcodeproj \
             -scheme AnalyticsConnector \
             -sdk macosx \
-            -destination 'platform=macosx' \
+            -destination 'platform=macOS' \
 
       - name: tvOS Build 
         run: |
@@ -89,7 +89,7 @@ jobs:
             -project AnalyticsConnector.xcodeproj \
             -scheme AnalyticsConnector \
             -sdk macosx \
-            -destination 'platform=macosx' \
+            -destination 'platform=macOS' \
             test
 
       - name: tvOS Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   authorize:
     name: Authorize
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: ${{ github.actor }} permission check to do a release
         uses: octokit/request-action@57ec46afcc4c58c813af3afe67e57ced1ea9f165 # v2.0.0
@@ -23,16 +23,16 @@ jobs:
 
   release:
     name: Release
-    runs-on: macos-14
+    runs-on: macos-15
     needs: [authorize]
     steps:
 
       - name: Checkout
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set Xcode 15.4
+      - name: Set Xcode 16.3
         run: |
-          sudo xcode-select -switch /Applications/Xcode_15.4.app
+          sudo xcode-select -switch /Applications/Xcode_16.3.app
 
       - name: iOS Build 
         run: |
@@ -40,7 +40,7 @@ jobs:
             -project AnalyticsConnector.xcodeproj \
             -scheme AnalyticsConnector \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.5'
+            -destination 'platform=iOS Simulator,name=iPhone 16'
 
       - name: macOS Build 
         run: |
@@ -72,7 +72,7 @@ jobs:
             -project AnalyticsConnector.xcodeproj \
             -scheme AnalyticsConnector \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.5'
+            -destination 'platform=iOS Simulator,name=iPhone 16'
 
       - name: macOS Tests
         run: |
@@ -101,8 +101,7 @@ jobs:
             -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
             test
 
-      # Install missing sdk for pod lint
-      # Remove this step after the runner upgraded to macos-15
+      # Ensure the visionOS platform is available for pod lint
       - name: Install visionOS simulator
         run: xcodebuild -downloadPlatform visionOS -quiet
 
@@ -126,7 +125,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Semantic Release --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
             -project AnalyticsConnector.xcodeproj \
             -scheme AnalyticsConnector \
             -sdk xrsimulator \
-            -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+            -destination 'platform=visionOS Simulator,OS=2.4,name=Apple Vision Pro' \
 
       - name: iOS Tests
         run: |
@@ -107,7 +107,7 @@ jobs:
             -project AnalyticsConnector.xcodeproj \
             -scheme AnalyticsConnector \
             -sdk xrsimulator \
-            -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+            -destination 'platform=visionOS Simulator,OS=2.4,name=Apple Vision Pro' \
             test
 
       - name: Validate Podfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,16 @@ jobs:
         run: |
           sudo xcode-select -switch /Applications/Xcode_16.3.app
 
-      - name: iOS Build 
+      - name: Install Apple platform SDKs
+        run: |
+          # Warm up CoreSimulator to avoid "Unable to connect to simulator":
+          # https://github.com/actions/runner-images/issues/12862#issuecomment-3239326872
+          xcrun simctl list > /dev/null
+          sudo xcodebuild -downloadPlatform iOS
+          sudo xcodebuild -downloadPlatform tvOS
+          sudo xcodebuild -downloadPlatform visionOS
+
+      - name: iOS Build
         run: |
           xcodebuild \
             -project AnalyticsConnector.xcodeproj \
@@ -100,10 +109,6 @@ jobs:
             -sdk xrsimulator \
             -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
             test
-
-      # Ensure the visionOS platform is available for pod lint
-      - name: Install visionOS simulator
-        run: xcodebuild -downloadPlatform visionOS -quiet
 
       - name: Validate Podfile
         run: pod lib lint --allow-warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
             -project AnalyticsConnector.xcodeproj \
             -scheme AnalyticsConnector \
             -sdk xrsimulator \
-            -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+            -destination 'platform=visionOS Simulator,OS=2.4,name=Apple Vision Pro' \
 
       - name: iOS Tests
         run: |
@@ -90,5 +90,5 @@ jobs:
             -project AnalyticsConnector.xcodeproj \
             -scheme AnalyticsConnector \
             -sdk xrsimulator \
-            -destination 'platform=visionOS Simulator,name=Apple Vision Pro' \
+            -destination 'platform=visionOS Simulator,OS=2.4,name=Apple Vision Pro' \
             test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,16 @@ jobs:
         run: |
           sudo xcode-select -switch /Applications/Xcode_16.3.app
 
-      - name: iOS Build 
+      - name: Install Apple platform SDKs
+        run: |
+          # Warm up CoreSimulator to avoid "Unable to connect to simulator":
+          # https://github.com/actions/runner-images/issues/12862#issuecomment-3239326872
+          xcrun simctl list > /dev/null
+          sudo xcodebuild -downloadPlatform iOS
+          sudo xcodebuild -downloadPlatform tvOS
+          sudo xcodebuild -downloadPlatform visionOS
+
+      - name: iOS Build
         run: |
           xcodebuild \
             -project AnalyticsConnector.xcodeproj \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   test:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
-      - name: Checkout 
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Set Xcode 15.4
+      - name: Set Xcode 16.3
         run: |
-          sudo xcode-select -switch /Applications/Xcode_15.4.app
+          sudo xcode-select -switch /Applications/Xcode_16.3.app
 
       - name: iOS Build 
         run: |
@@ -23,7 +23,7 @@ jobs:
             -project AnalyticsConnector.xcodeproj \
             -scheme AnalyticsConnector \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 13,OS=15.5'
+            -destination 'platform=iOS Simulator,name=iPhone 16'
 
       - name: macOS Build 
         run: |
@@ -55,7 +55,7 @@ jobs:
             -project AnalyticsConnector.xcodeproj \
             -scheme AnalyticsConnector \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.5'
+            -destination 'platform=iOS Simulator,name=iPhone 16'
 
       - name: macOS Tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
             -project AnalyticsConnector.xcodeproj \
             -scheme AnalyticsConnector \
             -sdk macosx \
-            -destination 'platform=macosx' \
+            -destination 'platform=macOS' \
 
       - name: tvOS Build 
         run: |
@@ -72,7 +72,7 @@ jobs:
             -project AnalyticsConnector.xcodeproj \
             -scheme AnalyticsConnector \
             -sdk macosx \
-            -destination 'platform=macosx' \
+            -destination 'platform=macOS' \
             test
 
       - name: tvOS Tests


### PR DESCRIPTION
### Summary

The release dry run ([run 28897058155](https://github.com/amplitude/analytics-connector-ios/actions/runs/28897058155)) fails at semantic-release startup:

```
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.20.2.
```

Root cause: dependabot #20 (2026-04-02) bumped `semantic-release` to 25.x, whose `engines` requires Node ≥ 22.14, while the workflow pins `node-version: '20'`. The Release workflow hadn't run since, so this only surfaced now. All build/test/xcframework/checksum steps in that run passed — the failure is purely the Node engine check.

### Changes

- **Node 20 → 22** in the release workflow's `setup-node` (the actual unblocking fix).
- **Align the CI environment with AmplitudeCore-Swift / Amplitude-Swift**, which release successfully on this exact combination:
  - `runs-on: macos-14` → `macos-15`
  - Xcode 15.4 → **16.3** (same `xcode-select` as the other two repos)
  - **Install Apple platform SDKs** after selecting Xcode (same step as Core) — the macos-15 image only preinstalls runtimes for the default Xcode, so iOS/tvOS/visionOS must be downloaded; this replaces the old standalone visionOS download before pod lint
  - `actions/checkout` v2 → **v4**, same pinned SHA the suite uses
  - Simulator destinations updated to ones that exist in the Xcode 16.3 image (`iPhone 16`, no OS pin — the old `iPhone 12/13, OS=15.5` runtimes aren't installed there)

`test.yml` is updated too, so this PR's own CI validates the new toolchain before the next release attempt.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/amplitude-ios-iterop/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)