### PR TITLE
fix(tests): fix test target spm configuration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,6 @@ let package = Package(
             name: "AnalyticsConnectorTests",
             dependencies: ["AnalyticsConnector"],
             path: "Tests/AnalyticsConnectorTests",
-            exclude: ["Info.plist"]),
+            exclude: ["Info.plist", "ObjectiveCTests.m"]),
     ]
 )

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -39,6 +39,6 @@ let package = Package(
             name: "AnalyticsConnectorTests",
             dependencies: ["AnalyticsConnector"],
             path: "Tests/AnalyticsConnectorTests",
-            exclude: ["Info.plist"]),
+            exclude: ["Info.plist", "ObjectiveCTests.m"]),
     ]
 )

--- a/Package@swift-6.4.swift
+++ b/Package@swift-6.4.swift
@@ -40,7 +40,7 @@ let package = Package(
             name: "AnalyticsConnectorTests",
             dependencies: ["AnalyticsConnector"],
             path: "Tests/AnalyticsConnectorTests",
-            exclude: ["Info.plist"],
+            exclude: ["Info.plist", "ObjectiveCTests.m"],
             swiftSettings: [.swiftLanguageMode(.v5)]),
     ]
 )


### PR DESCRIPTION
### Summary

The current package is broken because SPM doesn't support mixed languages.

`swift package describe` fails with:
```
error: target at 'xxx/Tests/AnalyticsConnectorTests' contains mixed language source files; feature not supported
```

`swift test` fails with:
```
error: 'analytics-connector-ios': target at 'xxx/Tests/AnalyticsConnectorTests' contains mixed language source files; feature not supported
error: ExitCode(rawValue: 1)
[0/1] Planning build
```

By excluding the Objective-C file, both commands execute successfully.